### PR TITLE
Fixed Block.isDead() to check for <= 0

### DIFF
--- a/Ballz1/Block.swift
+++ b/Ballz1/Block.swift
@@ -58,7 +58,7 @@ class Block {
     }
     
     public func isDead() -> Bool {
-        return (hitCount! == 0)
+        return (hitCount! <= 0)
     }
     
     // MARK: Private functions


### PR DESCRIPTION
The issue is that somehow a block would get hit twice in a single
scene tick making its count < 0. isDead() was returning
(hitCount == 0) instead of (hitCount <= 0).

Fixes #15 