### PR TITLE
Block label doesn't hit zero anymore

### DIFF
--- a/Ballz1/HitBlockItem.swift
+++ b/Ballz1/HitBlockItem.swift
@@ -62,7 +62,10 @@ class HitBlockItem: Item {
     
     func hitItem() {
         hitCount! -= 1
-        labelNode!.text = "\(hitCount!)"
+        // Don't update the label to zero; it should just disappear
+        if hitCount! > 0 {
+            labelNode!.text = "\(hitCount!)"
+        }
     }
     
     func removeItem(scene: SKScene) -> Bool {


### PR DESCRIPTION
This was a bug where the block label reaches zero and then breaks. The blocks shouldn't update their label to zero, they should just disappear at this point.

Fixes #106 