### PR TITLE
Fixed the row generation bug.

### DIFF
--- a/Ballz1/ItemGenerator.swift
+++ b/Ballz1/ItemGenerator.swift
@@ -265,15 +265,15 @@ class ItemGenerator {
         // Pick from one of the pattern difficulties
         var pattern: [Int] = []
         let num = Int.random(in: 1...100)
-        if num < easyPatternPercent {
+        if num < getEasyPatternPercent() {
             // Easy pattern
             pattern = ItemGenerator.EASY_PATTERNS.randomElement()!
         }
-        else if (num >= easyPatternPercent) && (num < intermediatePatternPercent) {
+        else if (num >= getEasyPatternPercent()) && (num < getIntermediatePatternPercent()) {
             // Medium pattern
             pattern = ItemGenerator.INTERMEDIATE_PATTERNS.randomElement()!
         }
-        else if (num >= hardPatternPercent) {
+        else { // num is >= intermediatePatternPercent so pick a hard pattern
             // Hard pattern
             pattern = ItemGenerator.HARD_PATTERNS.randomElement()!
         }
@@ -454,6 +454,18 @@ class ItemGenerator {
         default:
             return nil
         }
+    }
+    
+    private func getEasyPatternPercent() -> Int {
+        return easyPatternPercent
+    }
+    
+    private func getIntermediatePatternPercent() -> Int {
+        return (easyPatternPercent + intermediatePatternPercent)
+    }
+    
+    private func getHardPatternPercent() -> Int {
+        return (easyPatternPercent + intermediatePatternPercent + hardPatternPercent)
     }
     
     // Gets the item count (doesn't include spacer items)


### PR DESCRIPTION
The bug was in the 'if/else if' comparisons for which pattern to
use. Also I wasn't actually using the percentage values correctly.
If the distribution was 10, 30, 60 (easy, medium, hard) it would
check:

if num < 10 { // easy }
else if num >= 10 && num < 30 { // medium }
else if num >= 60 { // hard }

That is super wrong. Need to start adding unit tests today for the
item generator and model to weed out any other silly bugs like
that.

Resolves #189 