### PR TITLE
After undoing a turn, warning flash goes away

### DIFF
--- a/Ballz1/Views/ContinuousGameScene.swift
+++ b/Ballz1/Views/ContinuousGameScene.swift
@@ -400,6 +400,11 @@ class ContinousGameScene: SKScene, SKPhysicsContactDelegate {
         
         // Update the score labels
         updateScore(highScore: gameModel!.highScore, gameScore: gameModel!.gameScore)
+        
+        if let _ = self.childNode(withName: "warningNode") {
+            // If we're currently flashing red to warn the user, remove that node from the screen
+            self.stopFlashingRed()
+        }
     }
     
     public func showPauseScreen() {


### PR DESCRIPTION
I can't think of a single case where the user would undo and the warning should stay. So after undoing a turn we just check to see if the warning flash is showing and if it is, we remove it.