### PR TITLE
Fixed warning user after restoring game state.

### DIFF
--- a/Ballz1/Models/ContinousGameModel.swift
+++ b/Ballz1/Models/ContinousGameModel.swift
@@ -196,12 +196,15 @@ class ContinuousGameModel {
     
     // MARK: Initialization functions
     required init(view: SKView, blockSize: CGSize, ballRadius: CGFloat) {
-        // State should always be initialized to READY
+        state = WAITING
+        
+        // Try to load persistent data
         if false == loadPersistentState() {
             // Defaults to load highScore of 0
             persistentData = PersistentData(highScore: highScore)
         }
         
+        // Try to load game state
         if false == loadGameState() {
             // Defaults to loading gameScore of 0
             gameState = GameState(gameScore: gameScore, userWasSaved: userWasSaved)
@@ -247,6 +250,9 @@ class ContinuousGameModel {
             
             // We need to set this to false to avoid loading old turn state
             prevTurnSaved = false
+            
+            // Set state to waiting so the game checks to see whether or not to warn the user or end the game
+            state = WAITING
             
             return true
         }

--- a/Ballz1/Views/ContinuousGameScene.swift
+++ b/Ballz1/Views/ContinuousGameScene.swift
@@ -518,10 +518,7 @@ class ContinousGameScene: SKScene, SKPhysicsContactDelegate {
         // Update the score labels
         updateScore(highScore: gameModel!.highScore, gameScore: gameModel!.gameScore)
         
-        if let _ = self.childNode(withName: "warningNode") {
-            // If we're currently flashing red to warn the user, remove that node from the screen
-            self.stopFlashingRed()
-        }
+        // Game model resets its state to WAITING so that the game checks loss risk or game over
     }
     
     public func showPauseScreen() {
@@ -701,14 +698,23 @@ class ContinousGameScene: SKScene, SKPhysicsContactDelegate {
         
         // Add the balls to the scene
         var ballPosition = CGPoint(x: view!.frame.midX, y: groundNode!.size.height + ballRadius!)
-        if gameModel!.isReady() {
+        if gameModel!.isWaiting() {
             // This means we loaded a saved game state so get the origin point
+            // The reason we load the game model in a WAITING state after loading a game is because during the WAITING state we:
+            // 1. Check if we're about to lose
+            // 2. Check if the game is over
+            // And we want to re-warn the user that they're about to lose if they are one row away from a game over
             ballPosition = gameModel!.ballManager!.getOriginPoint()
             addBallCountLabel()
         }
-        else {
+        else if gameModel!.isTurnOver() {
             // We're starting a new game
+            // The reason we start the game model in a TURN_OVER state for a new game is because in this state
+            // the game scene code will add a new row to the scene and animate all items down a row
             displayEncouragement(emoji: "🎬", text: "Action!")
+        }
+        else {
+            print("Game model loaded in an unusual state")
         }
         
         updateScore(highScore: gameModel!.highScore, gameScore: gameModel!.gameScore)


### PR DESCRIPTION
Did this by loading game state in WAITING state after restoring
saved game. Also after undoing a turn, the game model code will
reset its state to WAITING. This is so that we re-check whether or
not we need to warn the user.

Fixes #268 