### PR TITLE
Side wall zposition removed.

### DIFF
--- a/Ballz1/Views/ContinuousGameScene.swift
+++ b/Ballz1/Views/ContinuousGameScene.swift
@@ -932,7 +932,7 @@ class ContinousGameScene: SKScene, SKPhysicsContactDelegate {
         leftWallLine.move(to: lwStartPoint)
         leftWallLine.addLine(to: lwEndPoint)
         leftWallNode = SKShapeNode()
-        leftWallNode!.zPosition = 101
+        //leftWallNode!.zPosition = 101
         leftWallNode!.path = leftWallLine
         leftWallNode!.name = "wall"
         leftWallNode!.strokeColor = colorScheme!.marginColor
@@ -955,7 +955,7 @@ class ContinousGameScene: SKScene, SKPhysicsContactDelegate {
         rightWallLine.move(to: rwStartPoint)
         rightWallLine.addLine(to: rwEndPoint)
         rightWallNode = SKShapeNode()
-        rightWallNode!.zPosition = 101
+        //rightWallNode!.zPosition = 101
         rightWallNode!.path = rightWallLine
         rightWallNode!.name = "wall"
         rightWallNode!.strokeColor = colorScheme!.marginColor


### PR DESCRIPTION
This allows the red flashing screen to show over the side walls,
and the ball projection path is still behind the walls.

Fixes #343 