### PR TITLE
Undo button improvements.

### DIFF
--- a/Ballz1/Controllers/ContinuousGameController.swift
+++ b/Ballz1/Controllers/ContinuousGameController.swift
@@ -247,17 +247,25 @@ class ContinuousGameController: UIViewController,
         }
     }
     
-    public func enableUndoButton() {
-        if GADRewardBasedVideoAd.sharedInstance().isReady && false == undoButton.isEnabled {
+    public func enableUndoButton(force: Bool = false) {
+        // Enable the undo button IF AND ONLY IF: 1) force is true, or 2) if a reward ad is loaded
+        if GADRewardBasedVideoAd.sharedInstance().isReady && false == undoButtonIsEnabled() {
             // If we've loaded a reward ad, enable the button
+            undoButton.alpha = ContinuousGameController.ENABLED_ALPHA
+        }
+        else if force {
             undoButton.alpha = ContinuousGameController.ENABLED_ALPHA
         }
     }
     
     public func disableUndoButton() {
-        if undoButton.isEnabled {
+        if undoButtonIsEnabled() {
             undoButton.alpha = ContinuousGameController.DISABLED_ALPHA
         }
+    }
+    
+    public func undoButtonIsEnabled() -> Bool {
+        return undoButton.alpha >= ContinuousGameController.ENABLED_ALPHA
     }
     
     @IBAction func returnToGameMenu(_ sender: Any) {
@@ -317,16 +325,25 @@ class ContinuousGameController: UIViewController,
     }
     
     @IBAction func undoTurn(_ sender: Any) {
-        print("Undo button alpha is \(undoButton.alpha)")
-        if undoButton.alpha < ContinuousGameController.ENABLED_ALPHA {
+        // If the button isn't enabled, notify the user
+        if false == undoButtonIsEnabled() {
             // If it's disabled, inform the user that they can't undo at this time
             let contScene = scene as! ContinousGameScene
             contScene.notifyCantUndo()
         }
+        // If the button is enabled, either show an ad if it's loaded or undo the turn if the ad isn't loaded
         else {
-            // Set this variable so we know what type of reward to give the user
-            rewardType = ContinuousGameController.UNDO_REWARD
-            showRewardAd()
+            // Check if a reward ad is loaded
+            if GADRewardBasedVideoAd.sharedInstance().isReady {
+                // Set this variable so we know what type of reward to give the user
+                rewardType = ContinuousGameController.UNDO_REWARD
+                showRewardAd()
+            }
+            else {
+                // If no reward ad is loaded, just undo the turn
+                let contScene = scene as! ContinousGameScene
+                contScene.loadPreviousTurnState()
+            }
         }
     }
     

--- a/Ballz1/Views/ContinuousGameScene.swift
+++ b/Ballz1/Views/ContinuousGameScene.swift
@@ -39,6 +39,9 @@ class ContinousGameScene: SKScene, SKPhysicsContactDelegate {
     
     private var ballCountLabelMargin = CGFloat(0.05)
     
+    private var lastUndoTurnScore = 0
+    static private var MAX_TURNS_FORCE_UNDO = Int(5)
+    
     // Nodes that will be shown in the view
     private var groundNode: SKSpriteNode?
     private var ceilingNode: SKShapeNode?
@@ -553,6 +556,9 @@ class ContinousGameScene: SKScene, SKPhysicsContactDelegate {
             return
         }
         
+        // Save the score of the last turn that the user chose to undo (we wait 5 turns before forcing it to re-enable it)
+        lastUndoTurnScore = gameModel!.gameScore
+        
         // Get the old item array so we can remove all of those items
         let oldItemArray = gameModel!.itemGenerator!.itemArray
         // Get the old ball array so we can remove all of them
@@ -872,6 +878,9 @@ class ContinousGameScene: SKScene, SKPhysicsContactDelegate {
         
         // Move the items down in the view
         animateItems()
+        
+        // Set the last turn undone as the current game score
+        lastUndoTurnScore = gameModel!.gameScore
     }
     
     // Checks whether or not a point is in the bounds of the game as opposed to the top or bottom margins
@@ -1448,7 +1457,14 @@ class ContinousGameScene: SKScene, SKPhysicsContactDelegate {
     
     private func enableUndoButton() {
         if let controller = gameController {
-            controller.enableUndoButton()
+            if gameModel!.gameScore - lastUndoTurnScore >= ContinousGameScene.MAX_TURNS_FORCE_UNDO {
+                // Force the controller to enable the undo button if 5 turns have passed
+                controller.enableUndoButton(force: true)
+            }
+            else {
+                // Enable the undo button if an ad is loaded
+                controller.enableUndoButton()
+            }
         }
         else {
             // GameController variable not set; can't enable undo button


### PR DESCRIPTION
It is enabled after 5 turns regardless of whether or not an ad is
loaded. If it is disabled it will inform the user they can't undo.

Resolves #396