### PR TITLE
Potentially fixed lagging after reward ads.

### DIFF
--- a/Ballz1/BallProjection.swift
+++ b/Ballz1/BallProjection.swift
@@ -32,7 +32,7 @@ class BallProjection {
     
     // Updates where the ball path projection is pointing
     public func updateArrow(startPoint: CGPoint, touchPoint: CGPoint, ceilingHeight: CGFloat, groundHeight: CGFloat) -> CGPoint {
-        let maxOffset = CGFloat(400)
+        let maxOffset = CGFloat(200)
         var newTouchPoint = touchPoint
         
         // This correction is here to fix a bug:

--- a/Ballz1/Controllers/ContinuousGameController.swift
+++ b/Ballz1/Controllers/ContinuousGameController.swift
@@ -176,6 +176,14 @@ class ContinuousGameController: UIViewController,
             // Set showedReward to false
             showedReward = false
         }
+        
+        // Unpause the game
+        let scene = self.scene as! ContinousGameScene
+        scene.isPaused = false
+        if let view = self.view as! SKView? {
+            view.isPaused = false
+        }
+        print("Unpaused game")
     }
     
     public func rewardBasedVideoAd(_ rewardBasedVideoAd: GADRewardBasedVideoAd, didFailToLoadWithError error: Error) {
@@ -202,6 +210,13 @@ class ContinuousGameController: UIViewController,
     public func showRewardAd() {
         // Show the reward ad if we can
         if GADRewardBasedVideoAd.sharedInstance().isReady {
+            // Pause the game
+            let scene = self.scene as! ContinousGameScene
+            scene.isPaused = true
+            if let view = self.view as! SKView? {
+                view.isPaused = true
+            }
+            print("Pausing game")
             // MARK: Bug - to avoid a weird bug, I need to load a new view with its own View Controller
             self.present(rewardAdViewController, animated: true, completion: nil)
         }


### PR DESCRIPTION
I fixed this by following google's suggestion of pausing the game
during the ad and unpausing it after the ad completes. This seems
to fix it.

Resolves #407 