### PR TITLE
Removed ball items from generation.

### DIFF
--- a/Ballz1/ItemGenerator.swift
+++ b/Ballz1/ItemGenerator.swift
@@ -367,6 +367,13 @@ class ItemGenerator {
         }
     }
     
+    // Removes balls from the item generator's generation list
+    public func removeBallTypeGeneration() {
+        nonBlockTypeArray = []
+        addNonBlockItemType(type: ItemGenerator.SPACER, percentage: 98)
+        addNonBlockItemType(type: ItemGenerator.BOMB, percentage: 2)
+    }
+    
     public func getBlockCount() -> Int {
         var count = 0
         for row in itemArray {

--- a/Ballz1/Models/LevelsGameModel.swift
+++ b/Ballz1/Models/LevelsGameModel.swift
@@ -167,6 +167,9 @@ class LevelsGameModel {
                                       useDrand: true,
                                       seed: levelCount)
         
+        // We don't want to have ball items in levels
+        itemGenerator!.removeBallTypeGeneration()
+        
         // XXX This should be based on the level number (the higher the level, the more difficult it should be)
         // Addressed in issue #429
         itemGenerator!.easyPatternPercent = 40


### PR DESCRIPTION
Didn't want to have ball items being added in levels. It breaks
the consistency of randomly generated levels with seeded numbers
because it affects the hit block count.

Resolves #435 