### PR TITLE
Fixed bug that breaks game when undoing turn.

### DIFF
--- a/Ballz1/Views/ContinuousGameScene.swift
+++ b/Ballz1/Views/ContinuousGameScene.swift
@@ -546,7 +546,7 @@ class ContinousGameScene: GameScene {
         // Tell the item generator and game model to prepare the new item array
         let success = gameModel!.loadPreviousTurnState()
         
-        if (false == gameModel!.loadPreviousTurnState()) || (false == loadPreviousBallState()) {
+        if (false == success) || (false == loadPreviousBallState()) {
             return
         }
         


### PR DESCRIPTION
Turns out I was calling loadPreviousTurnState() function twice in
classic game mode.

Resolves #574 